### PR TITLE
Check if "eval_metric" is a list before taking the first element

### DIFF
--- a/wideboost/wrappers/wxgb.py
+++ b/wideboost/wrappers/wxgb.py
@@ -106,8 +106,10 @@ def get_eval_metric(params,obj):
         'squarederror':eval(squarederror,obj,'squarederror'),
         'rmse':eval(rmse,obj,'rmse')
     }
-    print("Taking first argument of eval_metric. Multiple evals not supported using xgboost backend.")
-    return output_dict[params['eval_metric'][0]]
+    if isinstance(params['eval_metric'], list):
+    	print("Taking first argument of eval_metric. Multiple evals not supported using xgboost backend.")
+    	return output_dict[params['eval_metric'][0]]
+    return output_dict[params['eval_metric']]
 
 def get_objective(params):
     output_dict = {

--- a/wideboost/wrappers/wxgb.py
+++ b/wideboost/wrappers/wxgb.py
@@ -106,9 +106,9 @@ def get_eval_metric(params,obj):
         'squarederror':eval(squarederror,obj,'squarederror'),
         'rmse':eval(rmse,obj,'rmse')
     }
-    if isinstance(params['eval_metric'], list):
-    	print("Taking first argument of eval_metric. Multiple evals not supported using xgboost backend.")
-    	return output_dict[params['eval_metric'][0]]
+    if isinstance(params['eval_metric'], list) or isinstance(params['eval_metric'], tuple):
+        print("Taking first argument of eval_metric. Multiple evals not supported using xgboost backend.")
+        return output_dict[params['eval_metric'][0]]
     return output_dict[params['eval_metric']]
 
 def get_objective(params):


### PR DESCRIPTION
XGBoost supports passing a single metric name or a list of metrics for "eval_metric". Check if "eval_metric" is a list before taking the first element. Otherwise, `feval` is not overwritten, and there's no warning.